### PR TITLE
autopep8: read settings from configuration files

### DIFF
--- a/pyformat.py
+++ b/pyformat.py
@@ -46,9 +46,9 @@ def formatters(aggressive):
     if aggressive:
         yield autoflake.fix_code
         autopep8_options = autopep8.parse_args(
-            [''] + int(aggressive) * ['--aggressive'])
+            [''] + int(aggressive) * ['--aggressive'], apply_config=True)
     else:
-        autopep8_options = None
+        autopep8_options = autopep8.parse_args([''], apply_config=True)
 
     yield lambda code: autopep8.fix_code(code, options=autopep8_options)
     yield docformatter.format_code


### PR DESCRIPTION
Our project autopep8 settings are stored in setup.cfg. Then I execute `autorpep8` directly they are works. But then I execute pyformat they are don't works. 
This patch tells pyformat apply autopep8 settings from configuration files.