### PR TITLE
Remove imports and variables

### DIFF
--- a/pyformat.py
+++ b/pyformat.py
@@ -41,8 +41,8 @@ import unify
 __version__ = '0.6'
 
 
-def formatters(aggressive, apply_config, filename='', remove_all_unused_imports=False,
-               remove_unused_variables=False):
+def formatters(aggressive, apply_config, filename='',
+               remove_all_unused_imports=False, remove_unused_variables=False):
     """Return list of code formatters."""
     if aggressive:
         yield lambda code: autoflake.fix_code(
@@ -62,7 +62,8 @@ def formatters(aggressive, apply_config, filename='', remove_all_unused_imports=
 
 
 def format_code(source, aggressive=False, apply_config=False, filename='',
-                remove_all_unused_imports=False, remove_unused_variables=False):
+                remove_all_unused_imports=False,
+                remove_unused_variables=False):
     """Return formatted source code."""
     formatted_source = source
 
@@ -88,12 +89,13 @@ def format_file(filename, args, standard_out):
     if not source:
         return False
 
-    formatted_source = format_code(source,
-                                   aggressive=args.aggressive,
-                                   apply_config=args.config,
-                                   filename=filename,
-                                   remove_all_unused_imports=args.remove_all_unused_imports,
-                                   remove_unused_variables=args.remove_unused_variables)
+    formatted_source = format_code(
+        source,
+        aggressive=args.aggressive,
+        apply_config=args.config,
+        filename=filename,
+        remove_all_unused_imports=args.remove_all_unused_imports,
+        remove_unused_variables=args.remove_unused_variables)
 
     if source != formatted_source:
         if args.in_place:
@@ -170,7 +172,8 @@ def parse_args(argv):
     parser.add_argument('-a', '--aggressive', action='count', default=0,
                         help='use more aggressive formatters')
     parser.add_argument('--remove-all-unused-imports', action='store_true',
-                        help='remove all unused imports, not just standard library (requires "aggresive")')
+                        help='remove all unused imports, not just standard library \
+(requires "aggresive")')
     parser.add_argument('--remove-unused-variables', action='store_true',
                         help='remove unused variables (requires "aggresive")')
     parser.add_argument('-j', '--jobs', type=int, metavar='n', default=1,

--- a/pyformat.py
+++ b/pyformat.py
@@ -172,10 +172,11 @@ def parse_args(argv):
     parser.add_argument('-a', '--aggressive', action='count', default=0,
                         help='use more aggressive formatters')
     parser.add_argument('--remove-all-unused-imports', action='store_true',
-                        help='remove all unused imports, not just standard library \
-(requires "aggresive")')
+                        help='remove all unused imports, '
+                             'not just standard library '
+                             '(requires "aggressive")')
     parser.add_argument('--remove-unused-variables', action='store_true',
-                        help='remove unused variables (requires "aggresive")')
+                        help='remove unused variables (requires "aggressive")')
     parser.add_argument('-j', '--jobs', type=int, metavar='n', default=1,
                         help='number of parallel jobs; '
                              'match CPU count if value is less than 1')
@@ -200,6 +201,12 @@ def parse_args(argv):
     if args.jobs < 1:
         import multiprocessing
         args.jobs = multiprocessing.cpu_count()
+
+    if args.remove_all_unused_imports and not args.aggressive:
+        parser.error('--remove-all-unused-imports requires --aggressive')
+
+    if args.remove_unused_variables and not args.aggressive:
+        parser.error('--remove-unused-variables requires --aggressive')
 
     return args
 

--- a/pyformat.py
+++ b/pyformat.py
@@ -92,7 +92,8 @@ def format_file(filename, args, standard_out):
                                    aggressive=args.aggressive,
                                    apply_config=args.config,
                                    filename=filename,
-                                   remove_all_unused_imports=args.remove_all_unused_imports)
+                                   remove_all_unused_imports=args.remove_all_unused_imports,
+                                   remove_unused_variables=args.remove_unused_variables)
 
     if source != formatted_source:
         if args.in_place:
@@ -169,7 +170,9 @@ def parse_args(argv):
     parser.add_argument('-a', '--aggressive', action='count', default=0,
                         help='use more aggressive formatters')
     parser.add_argument('--remove-all-unused-imports', action='store_true',
-                        help='remove all unused imports, not just standard library')
+                        help='remove all unused imports, not just standard library (requires "aggresive")')
+    parser.add_argument('--remove-unused-variables', action='store_true',
+                        help='remove unused variables (requires "aggresive")')
     parser.add_argument('-j', '--jobs', type=int, metavar='n', default=1,
                         help='number of parallel jobs; '
                              'match CPU count if value is less than 1')

--- a/pyformat.py
+++ b/pyformat.py
@@ -85,7 +85,8 @@ def format_file(filename, args, standard_out):
     formatted_source = format_code(source,
                                    aggressive=args.aggressive,
                                    apply_config=args.config,
-                                   filename=filename)
+                                   filename=filename,
+                                   remove_all_unused_imports=args.remove_all_unused_imports)
 
     if source != formatted_source:
         if args.in_place:
@@ -161,6 +162,8 @@ def parse_args(argv):
                         help='drill down directories recursively')
     parser.add_argument('-a', '--aggressive', action='count', default=0,
                         help='use more aggressive formatters')
+    parser.add_argument('--remove-all-unused-imports', action='store_true',
+                        help='remove all unused imports, not just standard library')
     parser.add_argument('-j', '--jobs', type=int, metavar='n', default=1,
                         help='number of parallel jobs; '
                              'match CPU count if value is less than 1')

--- a/pyformat.py
+++ b/pyformat.py
@@ -41,10 +41,14 @@ import unify
 __version__ = '0.6'
 
 
-def formatters(aggressive, apply_config, filename='', remove_all_unused_imports=False):
+def formatters(aggressive, apply_config, filename='', remove_all_unused_imports=False,
+               remove_unused_variables=False):
     """Return list of code formatters."""
     if aggressive:
-        yield lambda code: autoflake.fix_code(code, remove_all_unused_imports=remove_all_unused_imports)
+        yield lambda code: autoflake.fix_code(
+            code,
+            remove_all_unused_imports=remove_all_unused_imports,
+            remove_unused_variables=remove_unused_variables)
         autopep8_options = autopep8.parse_args(
             [filename] + int(aggressive) * ['--aggressive'],
             apply_config=apply_config)
@@ -58,11 +62,13 @@ def formatters(aggressive, apply_config, filename='', remove_all_unused_imports=
 
 
 def format_code(source, aggressive=False, apply_config=False, filename='',
-                remove_all_unused_imports=False):
+                remove_all_unused_imports=False, remove_unused_variables=False):
     """Return formatted source code."""
     formatted_source = source
 
-    for fix in formatters(aggressive, apply_config, filename, remove_all_unused_imports):
+    for fix in formatters(
+            aggressive, apply_config, filename,
+            remove_all_unused_imports, remove_unused_variables):
         formatted_source = fix(formatted_source)
 
     return formatted_source

--- a/pyformat.py
+++ b/pyformat.py
@@ -41,10 +41,10 @@ import unify
 __version__ = '0.6'
 
 
-def formatters(aggressive, apply_config, filename=''):
+def formatters(aggressive, apply_config, filename='', remove_all_unused_imports=False):
     """Return list of code formatters."""
     if aggressive:
-        yield autoflake.fix_code
+        yield lambda code: autoflake.fix_code(code, remove_all_unused_imports=remove_all_unused_imports)
         autopep8_options = autopep8.parse_args(
             [filename] + int(aggressive) * ['--aggressive'],
             apply_config=apply_config)
@@ -57,11 +57,12 @@ def formatters(aggressive, apply_config, filename=''):
     yield unify.format_code
 
 
-def format_code(source, aggressive=False, apply_config=False, filename=''):
+def format_code(source, aggressive=False, apply_config=False, filename='',
+                remove_all_unused_imports=False):
     """Return formatted source code."""
     formatted_source = source
 
-    for fix in formatters(aggressive, apply_config, filename):
+    for fix in formatters(aggressive, apply_config, filename, remove_all_unused_imports):
         formatted_source = fix(formatted_source)
 
     return formatted_source

--- a/test_pyformat.py
+++ b/test_pyformat.py
@@ -60,6 +60,12 @@ class TestUnits(unittest.TestCase):
                          pyformat.format_code(
                              'x = "abc" \\\n"ö"\n'))
 
+    def test_format_code_with_remove_all_unused_imports(self):
+        self.assertEqual("x = 'abc' \\\n    'ö'\n",
+                         pyformat.format_code(
+                             'import os\nx = "abc" \\\n"ö"\n', aggressive=True,
+                            remove_all_unused_imports=True))
+
     def test_format_multiple_files(self):
         with temporary_file('''\
 if True:

--- a/test_pyformat.py
+++ b/test_pyformat.py
@@ -63,7 +63,7 @@ class TestUnits(unittest.TestCase):
     def test_format_code_with_remove_all_unused_imports(self):
         self.assertEqual("x = 'abc' \\\n    'ö'\n",
                          pyformat.format_code(
-                             'import os\nx = "abc" \\\n"ö"\n', aggressive=True,
+                             'import mymodule\nx = "abc" \\\n"ö"\n', aggressive=True,
                              remove_all_unused_imports=True))
 
     def test_format_multiple_files(self):

--- a/test_pyformat.py
+++ b/test_pyformat.py
@@ -254,6 +254,22 @@ if True:
 
         self.assertGreater(args.jobs, 0)
 
+    def test_remove_all_unused_imports_requires_aggressive(self):
+        _stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        self.assertRaises(
+            SystemExit, pyformat.parse_args,
+            ['my_fake_program', '--remove-all-unused-imports', __file__])
+        sys.stderr = _stderr
+
+    def test_remove_unused_variables_requires_aggressive(self):
+        _stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        self.assertRaises(
+            SystemExit, pyformat.parse_args,
+            ['my_fake_program', '--remove-unused-variables', __file__])
+        sys.stderr = _stderr
+
     def test_ignore_hidden_directories(self):
         with temporary_directory() as directory:
             with temporary_directory(prefix='.',

--- a/test_pyformat.py
+++ b/test_pyformat.py
@@ -64,7 +64,7 @@ class TestUnits(unittest.TestCase):
         self.assertEqual("x = 'abc' \\\n    'ö'\n",
                          pyformat.format_code(
                              'import os\nx = "abc" \\\n"ö"\n', aggressive=True,
-                            remove_all_unused_imports=True))
+                             remove_all_unused_imports=True))
 
     def test_format_multiple_files(self):
         with temporary_file('''\
@@ -308,6 +308,28 @@ if True:
                 self.assertEqual(
                     '',
                     output_file.getvalue().strip())
+
+    def test_remove_all_unused_imports(self):
+        with temporary_file("""\
+import mymodule
+
+def test():
+    return 42
+""") as filename:
+            output_file = io.StringIO()
+            pyformat._main(argv=['my_fake_program',
+                                 '--in-place',
+                                 '--aggressive',
+                                 '--remove-all-unused-imports',
+                                 filename],
+                           standard_out=output_file,
+                           standard_error=None)
+            with open(filename) as f:
+                self.assertEqual('''\
+
+def test():
+    return 42
+''', f.read())
 
     def test_end_to_end(self):
         with temporary_file("""\

--- a/test_pyformat.py
+++ b/test_pyformat.py
@@ -337,6 +337,26 @@ def test():
     return 42
 ''', f.read())
 
+    def test_remove_unused_variables(self):
+        with temporary_file("""\
+def test():
+    x = 43
+    return 42
+""") as filename:
+            output_file = io.StringIO()
+            pyformat._main(argv=['my_fake_program',
+                                 '--in-place',
+                                 '--aggressive',
+                                 '--remove-unused-variables',
+                                 filename],
+                           standard_out=output_file,
+                           standard_error=None)
+            with open(filename) as f:
+                self.assertEqual('''\
+def test():
+    return 42
+''', f.read())
+
     def test_end_to_end(self):
         with temporary_file("""\
 import os

--- a/test_pyformat.py
+++ b/test_pyformat.py
@@ -66,6 +66,12 @@ class TestUnits(unittest.TestCase):
                              'import mymodule\nx = "abc" \\\n"ö"\n', aggressive=True,
                              remove_all_unused_imports=True))
 
+    def test_format_code_with_remove_unused_variables(self):
+        self.assertEqual("def test():\n    return 42\n",
+                         pyformat.format_code(
+                             'def test():\n    x = 4\n    return 42', aggressive=True,
+                             remove_unused_variables=True))
+
     def test_format_multiple_files(self):
         with temporary_file('''\
 if True:


### PR DESCRIPTION
`pyformat` does a lovely job of wrapping `autoflake` to make changes recommended by a linter. `autoflake` allows unused imports and variables to be removed, but the required flags aren't passed by `pyformat`.

This adds the ability, in "aggressive" mode, to request that all unused imports (not just standard library) and variables be removed (by `autoflake`).