### PR TITLE
show diff only when --diff

### DIFF
--- a/pyformat.py
+++ b/pyformat.py
@@ -103,12 +103,14 @@ def format_file(filename, args, standard_out):
             with autopep8.open_with_encoding(filename, mode='w',
                                              encoding=encoding) as output_file:
                 output_file.write(formatted_source)
-        else:
+        elif args.diff:
             diff = autopep8.get_diff_text(
                 io.StringIO(source).readlines(),
                 io.StringIO(formatted_source).readlines(),
                 filename)
             standard_out.write(''.join(diff))
+        else:
+            standard_out.write(formatted_source)
 
         return True
 
@@ -169,6 +171,8 @@ def parse_args(argv):
     parser = argparse.ArgumentParser(description=__doc__, prog='pyformat')
     parser.add_argument('-i', '--in-place', action='store_true',
                         help='make changes to files instead of printing diffs')
+    parser.add_argument('-d', '--diff', action='store_true',
+                        help='print the diff for the fixed source')
     parser.add_argument('-r', '--recursive', action='store_true',
                         help='drill down directories recursively')
     parser.add_argument('-a', '--aggressive', action='count', default=0,

--- a/test_pyformat.py
+++ b/test_pyformat.py
@@ -150,7 +150,7 @@ import os
 x = "abc"
 ''') as filename:
             output_file = io.StringIO()
-            pyformat._main(argv=['my_fake_program', filename],
+            pyformat._main(argv=['my_fake_program','--diff',  filename],
                            standard_out=output_file,
                            standard_error=None)
             self.assertEqual('''\
@@ -166,7 +166,7 @@ import os
 x = "abc"
 ''') as filename:
             output_file = io.StringIO()
-            pyformat._main(argv=['my_fake_program', '--aggressive', filename],
+            pyformat._main(argv=['my_fake_program', '--diff', '--aggressive', filename],
                            standard_out=output_file,
                            standard_error=None)
             self.assertEqual('''\
@@ -193,7 +193,7 @@ import my_own_module
 x = 1
 """) as filename:
             output_file = io.StringIO()
-            pyformat._main(argv=['my_fake_program', '--aggressive', filename],
+            pyformat._main(argv=['my_fake_program', '--diff', '--aggressive', filename],
                            standard_out=output_file,
                            standard_error=None)
             self.assertEqual("""\
@@ -321,6 +321,7 @@ if True:
                                      '--recursive',
                                      '--exclude=zap',
                                      '--exclude=x*oo*',
+                                     '--diff',
                                      directory],
                                standard_out=output_file,
                                standard_error=None)
@@ -397,7 +398,7 @@ def test():
 import os
 x = "abc"
 """) as filename:
-            output = subprocess.check_output(PYFORMAT_COMMAND + [filename])
+            output = subprocess.check_output(PYFORMAT_COMMAND + ['--diff', filename])
             self.assertEqual("""\
  import os
 -x = "abc"
@@ -436,6 +437,7 @@ ignore=E
 
                 output_file = io.StringIO()
                 pyformat._main(argv=['my_fake_program',
+                                     '--diff',
                                      '--aggressive',
                                      '--no-config',
                                      filename],


### PR DESCRIPTION
The current behavior of `pyformat` is different from `autopep8`, which returns diff only when --diff option is specified and otherwise returns the whole file content.
It would be nice if the behavior of `pyformat`, which currently returns diff always, could be the same as autopep8, because then users can use `pyformat` just by replacing their `autopep8` to `pyformat`.

For example, [this issue](https://github.com/Microsoft/vscode-python/pull/2950) of vscode is solved and vscode users can use `pyformat` with a simple modification of their configuration.