### PR TITLE
setup.py: unbreak 3.14: Str.s deprecated, use Str.value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def version():
     with open('pyformat.py') as input_file:
         for line in input_file:
             if line.startswith('__version__'):
-                return ast.parse(line).body[0].value.s
+                return ast.parse(line).body[0].value.value
 
 
 with open('README.rst') as readme:


### PR DESCRIPTION
`pip install pyformat` is broken on python 3.14. For instance in a github action it shows up as:

```
[...]
Collecting pyformat
  Downloading pyformat-1.0.tar.gz (7.4 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [24 lines of output]
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-tpmkuhz1/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-tpmkuhz1/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/tmp/pip-build-env-tpmkuhz1/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-tpmkuhz1/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 20, in <module>
        File "<string>", line 15, in version
      AttributeError: 'Constant' object has no attribute 's'
      [end of output]
```

The issue is that the ast attribute `s` has been deprecated for a while and has finally been removed in python3.14 (cf. https://docs.python.org/dev/whatsnew/3.14.html#id9)

```
>>> import ast
>>> ast.parse('__version__ = "1.0"').body[0].value.s
<ipython-input-4-c40fe7e7149a>:1: DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
  ast.parse('__version__ = "1.0"').body[0].value.s
'1.0'
>>> ast.parse('__version__ = "1.0"').body[0].value.value
'1.0'
```

This PR replaces `.s` with `.value`, please merge and upload a new version on pypi to unbreak the package for python 3.14.

Thank you!